### PR TITLE
LPAL-1954 - replace deprecated name with region in aws_region data source

### DIFF
--- a/kms.tf
+++ b/kms.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "cloudwatch_kms" {
     principals {
       type = "Service"
       identifiers = [
-        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "logs.${data.aws_region.current.region}.amazonaws.com",
         "cloudwatch.amazonaws.com"
       ]
     }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7.0"
+      version = ">= 6.0.0"
       configuration_aliases = [
         aws.us-east-1,
       ]


### PR DESCRIPTION
It might be necessary to make releases (maybe not as we have tags) and pin to them in the account module, otherwise merging this is going to immediately affect every account